### PR TITLE
Install smartmet-plugin-avi in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN dnf -y install https://download.fmi.fi/smartmet-open/rhel/9/x86_64/smartmet-
     dnf -y install jemalloc && \
     dnf -y install --setopt=install_weak_deps=False \
     smartmet-plugin-autocomplete \
+    smartmet-plugin-avi \
     smartmet-plugin-backend \
     smartmet-plugin-download \
     smartmet-plugin-edr \

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -17,6 +17,7 @@ RUN dnf -y install https://download.fmi.fi/smartmet-open/rhel/10/x86_64/smartmet
     dnf -y install jemalloc && \
     dnf -y install --setopt=install_weak_deps=False \
     smartmet-plugin-autocomplete \
+    smartmet-plugin-avi \
     smartmet-plugin-backend \
     smartmet-plugin-download \
     smartmet-plugin-edr \


### PR DESCRIPTION
## Summary
- Adds `smartmet-plugin-avi` to the dnf install list in both `Dockerfile` and `Dockerfile.rocky10`.
- Pairs with the existing `smartmet-engine-avi` (already pulled in transitively): users who turn on `smartmetConf.avi.enabled` in the [helm chart](https://github.com/fmidev/helm-charts/tree/main/charts/smartmetserver) get a working `/avi` plugin endpoint, not just the engine.
- Helm chart still ships with avi disabled by default, so existing deployments are unaffected.

## Why
While testing the AVI engine + plugin support added in the smartmetserver chart, smartmetd crashed at startup with:
```
Unable to load dynamic library plugin: /usr/share/smartmet/plugins/avi.so: cannot open shared object file: No such file or directory
```
`/usr/share/smartmet/plugins/` confirmed missing `avi.so` — only autocomplete, backend, download, edr, q3, timeseries, and wms ship today. The avi engine `.so` is present (it loads fine via the `smartmet-engine-avi` dependency).

## Test plan
- [ ] Image builds cleanly on both Rocky 9 and Rocky 10
- [ ] `/usr/share/smartmet/plugins/avi.so` is present in the resulting image
- [ ] With the helm chart's `smartmetConf.avi.enabled=true` and a working AVI PostGIS DB, smartmetd starts cleanly and responds at `/avi`

🤖 Generated with [Claude Code](https://claude.com/claude-code)